### PR TITLE
Renamed files to avoid name clashes with Mesa, added OpenMAX, fixed bug in egl.pc

### DIFF
--- a/pkgconfig/egl-vc.pc
+++ b/pkgconfig/egl-vc.pc
@@ -3,10 +3,10 @@ exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 
-Name: OpenVG
-Description: Fake OpenVG package for RPi
+Name: EGL
+Description: Fake EGL package for RPi
 Version: 10
 Requires: bcm_host
-Libs: -L${libdir} -lOpenVG
+Libs: -L${libdir} -lEGL -lGLESv2
 Cflags: -I${includedir}
 

--- a/pkgconfig/gles-vc.pc
+++ b/pkgconfig/gles-vc.pc
@@ -6,7 +6,7 @@ includedir=${prefix}/include
 Name: GLESv2
 Description: Fake GL ES 2 package for RPi
 Version: 10
-Requires: bcm_host
-Libs: -L${libdir} -lGLESv2
-Cflags: -I${includedir}
+Requires: egl-vc
+Libs:
+Cflags:
 

--- a/pkgconfig/openmax-il-vc.pc
+++ b/pkgconfig/openmax-il-vc.pc
@@ -1,0 +1,12 @@
+prefix=/opt/vc/src/hello_pi
+exec_prefix=${prefix}
+libdir=${exec_prefix}/libs/ilclient
+includedir=${prefix}/libs/ilclient
+
+Name: OpenMAX IL
+Description: Fake OpenMAX with IL client package for RPi
+Version: 10
+Requires: openmax-vc
+Libs: -L${libdir} -lilclient
+Cflags: -I${includedir}
+

--- a/pkgconfig/openmax-vc.pc
+++ b/pkgconfig/openmax-vc.pc
@@ -1,0 +1,12 @@
+prefix=/opt/vc
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: OpenMAX
+Description: Fake OpenMAX package for RPi
+Version: 10
+Requires: egl-vc
+Libs: -L${libdir} -lopenmaxil
+Cflags: -I${includedir} -I${includedir}/IL
+

--- a/pkgconfig/vg-vc.pc
+++ b/pkgconfig/vg-vc.pc
@@ -3,10 +3,10 @@ exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 
-Name: EGL
-Description: Fake EGL package for RPi
+Name: OpenVG
+Description: Fake OpenVG package for RPi
 Version: 10
-Requires: bcm_host
-Libs: -L${libdir} -lEGL
+Requires: egl-vc
+Libs: -L${libdir} -lOpenVG
 Cflags: -I${includedir}
 


### PR DESCRIPTION
libegl1-mesa also creates egl.pc. Renamed egl.pc as egl-vc.pc for
EGL Video Core, glesv2.pc as glesv2-vc.pc and others similarly.

Added files for OpenMAX and for OpenMAX using the Broadcom IL client
library.

Added library GLESv2 to egl-vc.pc as compiling EGL programs drags
in the GL ES library anyway.